### PR TITLE
#ZN-50 - Mobile: bad zoom control styles

### DIFF
--- a/app/frontend/stylesheets/components/map/map.scss
+++ b/app/frontend/stylesheets/components/map/map.scss
@@ -10,3 +10,9 @@
   top: 0px;
   width: 100vw;
 }
+
+.leaflet-control-container {
+  .leaflet-control-attribution.leaflet-control {
+    display: none;
+  }
+}

--- a/app/frontend/stylesheets/components/map/zoom_control.scss
+++ b/app/frontend/stylesheets/components/map/zoom_control.scss
@@ -7,10 +7,12 @@
     left: 7px;
   }
 
-  .leaflet-bar a,
-  .leaflet-bar a:hover {
-    height: 37px;
-    line-height: 37px;
-    width: 33px;
+  .leaflet-control-zoom {
+    .leaflet-bar a,
+    .leaflet-bar a:hover {
+      height: 37px;
+      line-height: 37px;
+      width: 33px;
+    }
   }
 }


### PR DESCRIPTION
Remove leaflet label at the bottom right corner

Concretize Zoom Controls styles to override default ones